### PR TITLE
Feat: update peer event prefix and help messages

### DIFF
--- a/src/peer/discovery.rs
+++ b/src/peer/discovery.rs
@@ -54,7 +54,7 @@ pub async fn handle_discovery_message(
             let is_new = !peer_list.update_last_seen(&addr);
             if is_new {
                 peer_list.add_or_update_peer(addr, msg.sender.clone());
-                println!("New peer discovered: {} ({})", msg.sender, addr);
+                println!("### New peer discovered: {} ({})", msg.sender, addr);
             }
 
             let socket_clone = socket.clone();
@@ -132,7 +132,7 @@ pub async fn handle_peer_list_message(
 
     // If we added new peers, log it
     if new_peers {
-        println!("Discovered new peers from peer list");
+        println!("### Discovered new peers from peer list");
     }
 
     Ok(())

--- a/src/peer/heartbeats.rs
+++ b/src/peer/heartbeats.rs
@@ -96,7 +96,7 @@ async fn check_peer_timeouts(peer_list: &SharedPeerList) {
 
     // Log removed peers
     for username in stale_peers {
-        println!("Peer timed out and was removed: {}", username);
+        println!("### Peer timed out and was removed: {}", username);
     }
 }
 
@@ -141,7 +141,7 @@ pub async fn handle_heartbeat_message(
                     // This is a genuinely new peer
                     peer_list.add_or_update_peer(addr, msg.sender.clone());
                     println!(
-                        "New peer discovered via heartbeat: {} ({})",
+                        "### New peer discovered via heartbeat: {} ({})",
                         msg.sender, addr
                     );
                 }

--- a/src/ui/commands.rs
+++ b/src/ui/commands.rs
@@ -6,7 +6,7 @@ pub async fn handle_command(input_line: &str, peer_list: SharedPeerList) -> Opti
     let command = input_line.split_whitespace().next().unwrap_or("");
 
     match command {
-        "/peers" => {
+        "/peers" | "/p" => {
             let peers = peer_list.lock().await.get_peers();
             if peers.is_empty() {
                 Some("@@@ No peers connected.".to_string())
@@ -28,7 +28,7 @@ pub async fn handle_command(input_line: &str, peer_list: SharedPeerList) -> Opti
                 Some(response)
             }
         }
-        "/remove" => {
+        "/remove" | "/rm" => {
             // Parse the index from the command
             let parts: Vec<&str> = input_line.split_whitespace().collect();
             if parts.len() != 2 {
@@ -54,24 +54,24 @@ pub async fn handle_command(input_line: &str, peer_list: SharedPeerList) -> Opti
                 Err(_) => Some("@@@ Invalid index format. Usage: /remove <index>".to_string()),
             }
         }
-        "/quit" => Some("exit".to_string()),
-        "/help" => {
+        "/quit" | "/q" => Some("exit".to_string()),
+        "/help" | "/h" => {
             let help_text = "\
         help?
         Available commands:
-            /peers          - Show list of connected peers
-            /remove <index> - Remove a peer by its index
-            /help           - Show this help message
-            /version        - Show version
-            /quit           - Quit the application
+            /[ p | peers ]           - Show list of connected peers
+            /[ rm | remove ] <index> - Remove a peer by its index
+            /[ h | help ]            - Show this help message
+            /[ v | version ]         - Show version
+            /[ q | quit ]            - Quit the application
 
         Legend of prefixes:
-            @@@             - Normal system messages
-            ###             - Peer related system messages
+            @@@                      - Normal system messages
+            ###                      - Peer related events
             ";
             Some("@@@ ".to_string() + help_text)
         }
-        "/version" => Some(format!("@@@ Version: {}", VERSION)),
+        "/version" | "/v" => Some(format!("@@@ Version: {}", VERSION)),
         _ => {
             if input_line.starts_with("/") {
                 // Unknown command starting with /

--- a/src/ui/commands.rs
+++ b/src/ui/commands.rs
@@ -1,3 +1,4 @@
+use crate::VERSION;
 use crate::peer::SharedPeerList;
 
 pub async fn handle_command(input_line: &str, peer_list: SharedPeerList) -> Option<String> {
@@ -56,13 +57,21 @@ pub async fn handle_command(input_line: &str, peer_list: SharedPeerList) -> Opti
         "/quit" => Some("exit".to_string()),
         "/help" => {
             let help_text = "\
-            Available commands:
-            /peers - Show list of connected peers
+        help?
+        Available commands:
+            /peers          - Show list of connected peers
             /remove <index> - Remove a peer by its index
-            /help  - Show this help message
+            /help           - Show this help message
+            /version        - Show version
+            /quit           - Quit the application
+
+        Legend of prefixes:
+            @@@             - Normal system messages
+            ###             - Peer related system messages
             ";
             Some("@@@ ".to_string() + help_text)
         }
+        "/version" => Some(format!("@@@ Version: {}", VERSION)),
         _ => {
             if input_line.starts_with("/") {
                 // Unknown command starting with /


### PR DESCRIPTION
### Summary
1. Add prefix to peer related event.
2. Add shortcuts for commands.
3. Improve help messages.
4. Add command to show version. (`/v` or `/version`)