### PR TITLE
feat: improve network discovery

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -228,8 +228,16 @@ async fn main() -> rustyline::Result<()> {
                 std::io::stdout().flush()?;
                 if line.starts_with("/") {
                     let peer_list_clone = peer_list.clone();
+                    let socket_clone = socket_send_clone.clone();
+                    let username_clone = username.clone();
                     if let Some(response) =
-                        ui::commands::handle_command(&line, peer_list_clone).await
+                        ui::commands::handle_command(
+                            &line, 
+                            peer_list_clone, 
+                            Some(socket_clone),
+                            Some(username_clone),
+                            Some(local_addr)
+                        ).await
                     {
                         if response == "exit" {
                             println!("@@@ bye!");

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,20 +126,21 @@ async fn main() -> rustyline::Result<()> {
 
     // Always send a discovery broadcast, regardless of whether the init port is available
     // This ensures we can find all peers, even after restarting
-    
+
     // Try to bind to the init port, but don't worry if it's already in use
-    let socket_recv_only_for_init = match UdpSocket::bind(format!("0.0.0.0:{}", DEFAULT_RECV_INIT_PORT)).await {
-        Ok(sock) => {
-            println!("@@@ Bound to init port {}", DEFAULT_RECV_INIT_PORT);
-            Some(Arc::new(sock))
-        },
-        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
-            // Port is in use, so another pung process is running
-            println!("@@@ Another pung instance detected on this machine");
-            None
-        },
-        Err(e) => return Err(e.into()),
-    };
+    let socket_recv_only_for_init =
+        match UdpSocket::bind(format!("0.0.0.0:{}", DEFAULT_RECV_INIT_PORT)).await {
+            Ok(sock) => {
+                println!("@@@ Bound to init port {}", DEFAULT_RECV_INIT_PORT);
+                Some(Arc::new(sock))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                // Port is in use, so another pung process is running
+                println!("@@@ Another pung instance detected on this machine");
+                None
+            }
+            Err(e) => return Err(e.into()),
+        };
 
     // Prepare shared socket for sending
     let socket_send_clone = socket_send.clone();
@@ -205,7 +206,7 @@ async fn main() -> rustyline::Result<()> {
         .await?;
     }
 
-    println!("@@@ To show known peers, type [/peers]");
+    println!("@@@ Enter [/h] to show available commands");
     let rl = Arc::new(Mutex::new(DefaultEditor::new()?));
 
     loop {
@@ -230,14 +231,14 @@ async fn main() -> rustyline::Result<()> {
                     let peer_list_clone = peer_list.clone();
                     let socket_clone = socket_send_clone.clone();
                     let username_clone = username.clone();
-                    if let Some(response) =
-                        ui::commands::handle_command(
-                            &line, 
-                            peer_list_clone, 
-                            Some(socket_clone),
-                            Some(username_clone),
-                            Some(local_addr)
-                        ).await
+                    if let Some(response) = ui::commands::handle_command(
+                        &line,
+                        peer_list_clone,
+                        Some(socket_clone),
+                        Some(username_clone),
+                        Some(local_addr),
+                    )
+                    .await
                     {
                         if response == "exit" {
                             println!("@@@ bye!");

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,6 @@
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
-use bincode::{Decode, Encode};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Encode, Decode)]
 pub enum MessageType {
@@ -18,6 +18,7 @@ pub struct Message {
     pub timestamp: i64,
     pub msg_type: MessageType,
     pub sender_addr: Option<String>, // String representation of SocketAddr for serialization
+    pub known_peers: Option<Vec<(String, String)>>, // (username, addr as string)
 }
 
 impl Message {
@@ -29,6 +30,7 @@ impl Message {
             timestamp: chrono::Utc::now().timestamp(),
             msg_type: MessageType::Chat,
             sender_addr: sender_addr.map(|addr| addr.to_string()),
+            known_peers: None,
         }
     }
 
@@ -40,10 +42,15 @@ impl Message {
             timestamp: chrono::Utc::now().timestamp(),
             msg_type: MessageType::Discovery,
             sender_addr: Some(sender_addr.to_string()),
+            known_peers: None,
         }
     }
 
-    pub fn new_heartbeat(sender: String, sender_addr: SocketAddr) -> Self {
+    pub fn new_heartbeat(
+        sender: String,
+        sender_addr: SocketAddr,
+        known_peers: Vec<(String, String)>,
+    ) -> Self {
         Message {
             sender,
             content: "HEARTBEAT".to_string(),
@@ -51,6 +58,7 @@ impl Message {
             timestamp: chrono::Utc::now().timestamp(),
             msg_type: MessageType::Heartbeat,
             sender_addr: Some(sender_addr.to_string()),
+            known_peers: Some(known_peers),
         }
     }
 
@@ -65,6 +73,7 @@ impl Message {
             timestamp: chrono::Utc::now().timestamp(),
             msg_type: MessageType::PeerList,
             sender_addr: Some(sender_addr.to_string()),
+            known_peers: None,
         }
     }
 }

--- a/src/peer/discovery.rs
+++ b/src/peer/discovery.rs
@@ -23,7 +23,7 @@ pub async fn start_discovery(
 }
 
 /// Sends a discovery message to the broadcast address on the receive port
-async fn send_discovery_message(
+pub async fn send_discovery_message(
     socket: Arc<UdpSocket>,
     username: &str,
     local_addr: SocketAddr,

--- a/src/peer/discovery.rs
+++ b/src/peer/discovery.rs
@@ -22,7 +22,7 @@ pub async fn start_discovery(
     Ok(())
 }
 
-/// Sends a discovery message to the broadcast address on the receive port
+/// Sends a discovery message to the broadcast address on multiple ports
 pub async fn send_discovery_message(
     socket: Arc<UdpSocket>,
     username: &str,
@@ -30,9 +30,17 @@ pub async fn send_discovery_message(
 ) -> std::io::Result<()> {
     let discovery_msg = Message::new_discovery(username.to_string(), local_addr);
 
-    // Broadcast to the specified receive port
+    // Broadcast to the default init port
     let broadcast_addr = format!("{BROADCAST_ADDR}:{}", DEFAULT_RECV_INIT_PORT);
     sender::send_message(socket.clone(), &discovery_msg, &broadcast_addr).await?;
+
+    // Also broadcast to the local port that this peer is using
+    // This helps reach peers that couldn't bind to the default init port
+    let local_port = local_addr.port();
+    if local_port != DEFAULT_RECV_INIT_PORT {
+        let alt_broadcast_addr = format!("{BROADCAST_ADDR}:{}", local_port);
+        sender::send_message(socket.clone(), &discovery_msg, &alt_broadcast_addr).await?;
+    }
 
     Ok(())
 }
@@ -50,10 +58,17 @@ pub async fn handle_discovery_message(
             // Add the peer to our list
             let mut peer_list = peer_list.lock().await;
 
+            // Check if this is a new peer before printing a message
+            let is_new = peer_list.find_username_by_addr(&addr).is_none();
+
             // Always add or update the peer with their exact (username, IP, port)
             // This ensures proper uniqueness and prevents cross-refreshing
             peer_list.add_or_update_peer(addr, msg.sender.clone());
-            println!("### Peer discovered: {} ({})", msg.sender, addr);
+
+            // Only print a message if this is a new peer
+            if is_new {
+                println!("### New peer discovered: {} ({})", msg.sender, addr);
+            }
 
             let socket_clone = socket.clone();
 
@@ -61,15 +76,34 @@ pub async fn handle_discovery_message(
             let response = Message::new_discovery(username.to_string(), local_addr);
             sender::send_message(socket_clone.clone(), &response, addr_str).await?;
 
-            // Optionally, send our peer list to the new peer
+            // Always send our peer list to the new peer (even if it's just us)
+            // This ensures complete peer discovery across the network
             let peers = peer_list.get_peers();
-            if !peers.is_empty() {
-                let peer_addrs: Vec<String> = peers.iter().map(|p| p.addr.to_string()).collect();
 
-                let peer_list_msg =
-                    Message::new_peer_list(username.to_string(), peer_addrs, local_addr);
-                sender::send_message(socket_clone.clone(), &peer_list_msg, addr_str).await?;
+            // Include ourselves in the peer list if we're not already there
+            let mut has_self = false;
+            for peer in &peers {
+                if peer.addr == local_addr {
+                    has_self = true;
+                    break;
+                }
             }
+
+            // Create the list of peer addresses to share
+            let mut peer_addrs: Vec<String> = peers.iter().map(|p| p.addr.to_string()).collect();
+
+            // Always include ourselves in the peer list we share
+            if !has_self {
+                peer_addrs.push(local_addr.to_string());
+            }
+
+            // Send the peer list message
+            let peer_list_msg =
+                Message::new_peer_list(username.to_string(), peer_addrs, local_addr);
+            sender::send_message(socket_clone.clone(), &peer_list_msg, addr_str).await?;
+
+            // Log that we shared our peer list
+            println!("@@@ Shared peer list with {} ({})", msg.sender, addr);
         }
     }
 
@@ -113,7 +147,7 @@ pub async fn handle_peer_list_message(
             // Always add or update the peer with their exact (username, IP, port)
             // This ensures proper uniqueness and prevents cross-refreshing
             let is_new = peer_list_lock.find_username_by_addr(&addr).is_none();
-            
+
             // Add the peer with their address
             if is_new {
                 // For new peers, use a temporary name until we learn their real username

--- a/src/peer/heartbeats.rs
+++ b/src/peer/heartbeats.rs
@@ -8,8 +8,8 @@ use tokio::net::UdpSocket;
 use tokio::time;
 
 // Constants for heartbeat
-const HEARTBEAT_INTERVAL: u64 = 10; // seconds
-const PEER_TIMEOUT: u64 = 30; // seconds
+const HEARTBEAT_INTERVAL: u64 = 6; // seconds
+const PEER_TIMEOUT: u64 = 15; // seconds
 
 /// Starts the heartbeat mechanism to maintain peer liveness
 pub async fn start_heartbeat(
@@ -68,10 +68,10 @@ async fn send_heartbeats(
         peer_list
             .get_peers()
             .into_iter()
-            .filter(|p| !(p.username == username && p.addr == local_addr))
             .map(|p| (p.username.clone(), p.addr.to_string()))
             .collect::<Vec<_>>()
     };
+
     let heartbeat_msg = Message::new_heartbeat(username.to_string(), local_addr, peers.clone());
     let socket_clone = socket.clone();
     // Send heartbeat to each peer

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -56,29 +56,12 @@ impl PeerList {
         // Generate a unique key for this peer
         let key = Self::generate_peer_key(&username, &addr);
 
-        // Check if we already have this exact peer
+        // Check if we already have this exact peer (by username and address)
         if let Some(existing_peer) = self.peers.get_mut(&key) {
             // Just update the last_seen time
             existing_peer.last_seen = Instant::now();
         } else {
-            // Check if we have another peer with the same address
-            let addr_exists = self.peers.values().any(|peer| peer.addr == addr);
-
-            // If the address exists, update that peer instead of creating a new one
-            if addr_exists {
-                // Find and remove the old peer entry
-                let old_key = self
-                    .peers
-                    .iter()
-                    .find(|(_, peer)| peer.addr == addr)
-                    .map(|(key, _)| key.clone());
-
-                if let Some(old_key) = old_key {
-                    self.peers.remove(&old_key);
-                }
-            }
-
-            // Add the new peer
+            // Add the new peer (do NOT merge or remove by address only)
             self.peers.insert(
                 key,
                 PeerInfo {
@@ -94,27 +77,21 @@ impl PeerList {
         self.peers.values().cloned().collect()
     }
 
-    pub fn update_last_seen(&mut self, addr: &SocketAddr) -> bool {
-        // Find peer by address
-        let peer_key = self
-            .peers
-            .iter()
-            .find(|(_, peer)| &peer.addr == addr)
-            .map(|(key, _)| key.clone());
-
-        if let Some(key) = peer_key {
-            if let Some(peer) = self.peers.get_mut(&key) {
-                peer.last_seen = Instant::now();
-                return true;
-            }
+    pub fn update_last_seen(&mut self, username: &str, addr: &SocketAddr) -> bool {
+        // Find peer by username and address (including port)
+        let key = Self::generate_peer_key(username, addr);
+        if let Some(peer) = self.peers.get_mut(&key) {
+            peer.last_seen = Instant::now();
+            return true;
         }
         false
     }
 
-    // Find a peer by address and return its username if found
+    // Find a peer by EXACT address (including port) and return its username if found
     pub fn find_username_by_addr(&self, addr: &SocketAddr) -> Option<String> {
         for peer in self.peers.values() {
-            if &peer.addr == addr {
+            // Only match if the FULL address (IP AND port) matches
+            if peer.addr.ip() == addr.ip() && peer.addr.port() == addr.port() {
                 return Some(peer.username.clone());
             }
         }
@@ -135,52 +112,6 @@ impl PeerList {
         }
 
         stale_peers
-    }
-
-    /// Consolidate duplicate users with the same username and IP
-    /// This helps clean up the peer list when users restart their application
-    /// and get assigned a new port
-    pub fn consolidate_duplicate_users(&mut self) {
-        // First, collect all peers by username and IP
-        let mut user_groups: HashMap<(String, std::net::IpAddr), Vec<String>> = HashMap::new();
-
-        // Group peers by username and IP
-        for (key, peer) in &self.peers {
-            let username = peer.username.clone();
-            let ip = peer.addr.ip();
-            let entry = user_groups.entry((username, ip)).or_default();
-            entry.push(key.clone());
-        }
-
-        // For each group with more than one entry, keep only the most recently seen
-        for ((_username, _ip), keys) in user_groups {
-            if keys.len() > 1 {
-                // Find the most recently seen peer in this group
-                let mut most_recent_key = keys[0].clone();
-                let mut most_recent_time = Instant::now() - Duration::from_secs(9999); // Very old time
-
-                for key in &keys {
-                    if let Some(peer) = self.peers.get(key) {
-                        if peer.last_seen > most_recent_time {
-                            most_recent_time = peer.last_seen;
-                            most_recent_key = key.clone();
-                        }
-                    }
-                }
-
-                // Remove all but the most recent peer
-                for key in keys {
-                    if key != most_recent_key {
-                        if let Some(peer) = self.peers.remove(&key) {
-                            println!(
-                                "@@@ Consolidated duplicate peer: {} at {}",
-                                peer.username, peer.addr
-                            );
-                        }
-                    }
-                }
-            }
-        }
     }
 
     pub fn remove_peer_by_index(&mut self, index: usize) -> Option<PeerInfo> {

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -77,16 +77,6 @@ impl PeerList {
         self.peers.values().cloned().collect()
     }
 
-    pub fn update_last_seen(&mut self, username: &str, addr: &SocketAddr) -> bool {
-        // Find peer by username and address (including port)
-        let key = Self::generate_peer_key(username, addr);
-        if let Some(peer) = self.peers.get_mut(&key) {
-            peer.last_seen = Instant::now();
-            return true;
-        }
-        false
-    }
-
     // Find a peer by EXACT address (including port) and return its username if found
     pub fn find_username_by_addr(&self, addr: &SocketAddr) -> Option<String> {
         for peer in self.peers.values() {


### PR DESCRIPTION
### Summary
1. Support running multiple `pung` processes on the same machine.
2. Refactor the broadcast mechanism.
3. Add a new command `/b` or `/broadcast` to allow manual broadcasting by users.
4. Send a heartbeat immediately upon startup to reduce potential discovery delays.
5. Fix some subtle bugs on updating last seen records.