### PR TITLE
Fix: zombie peer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "pung"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bincode",
  "cargo-watch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pung"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
### Summary
1. Add a `recently_removed` record to prevent zombie peer re-joining via heartbeats